### PR TITLE
add HTTPClient interface and context to all HTTP requests

### DIFF
--- a/opentok/account.go
+++ b/opentok/account.go
@@ -2,6 +2,7 @@ package opentok
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -47,8 +48,13 @@ type Project struct {
 	EnvironmentDescription string `json:"environmentDescription"`
 }
 
-// CreateProject creates an OpenTok API key and secret for a project.
+// CreateProject creates an OpenTok API key and secret for a project..
 func (ot *OpenTok) CreateProject(projectName string) (*Project, error) {
+	return ot.CreateProjectContext(context.Background(), projectName)
+}
+
+// CreateProjectContext uses ctx for HTTP requests.
+func (ot *OpenTok) CreateProjectContext(ctx context.Context, projectName string) (*Project, error) {
 	jsonStr := []byte{}
 	if projectName != "" {
 		jsonStr = []byte(`{ "name": "` + projectName + `" }`)
@@ -72,8 +78,7 @@ func (ot *OpenTok) CreateProject(projectName string) (*Project, error) {
 	req.Header.Add("X-OPENTOK-AUTH", jwt)
 	req.Header.Add("User-Agent", SDKName+"/"+SDKVersion)
 
-	client := &http.Client{}
-	res, err := client.Do(req)
+	res, err := ot.httpClient.Do(req.WithContext(ctx))
 	if err != nil {
 		return nil, err
 	}
@@ -91,8 +96,13 @@ func (ot *OpenTok) CreateProject(projectName string) (*Project, error) {
 	return project, nil
 }
 
-// ListProjects returns the records for all projects.
+// ListProjectsContext uses ctx for HTTP requests.
 func (ot *OpenTok) ListProjects() ([]*Project, error) {
+	return ot.ListProjectsContext(context.Background())
+}
+
+// ListProjectsContext uses ctx for HTTP requests..
+func (ot *OpenTok) ListProjectsContext(ctx context.Context) ([]*Project, error) {
 	//Create jwt token
 	jwt, err := ot.jwtToken(accountToken)
 	if err != nil {
@@ -108,8 +118,7 @@ func (ot *OpenTok) ListProjects() ([]*Project, error) {
 	req.Header.Add("X-OPENTOK-AUTH", jwt)
 	req.Header.Add("User-Agent", SDKName+"/"+SDKVersion)
 
-	client := &http.Client{}
-	res, err := client.Do(req)
+	res, err := ot.httpClient.Do(req.WithContext(ctx))
 	if err != nil {
 		return nil, err
 	}
@@ -129,6 +138,11 @@ func (ot *OpenTok) ListProjects() ([]*Project, error) {
 
 // GetProject returns a project details record describing the project.
 func (ot *OpenTok) GetProject(projectAPIKey string) (*Project, error) {
+	return ot.GetProjectContext(context.Background(), projectAPIKey)
+}
+
+// GetProjectContext uses ctx for HTTP requests.
+func (ot *OpenTok) GetProjectContext(ctx context.Context, projectAPIKey string) (*Project, error) {
 	if projectAPIKey == "" {
 		return nil, fmt.Errorf("Cannot get project information without a project API key")
 	}
@@ -148,8 +162,7 @@ func (ot *OpenTok) GetProject(projectAPIKey string) (*Project, error) {
 	req.Header.Add("X-OPENTOK-AUTH", jwt)
 	req.Header.Add("User-Agent", SDKName+"/"+SDKVersion)
 
-	client := &http.Client{}
-	res, err := client.Do(req)
+	res, err := ot.httpClient.Do(req.WithContext(ctx))
 	if err != nil {
 		return nil, err
 	}
@@ -167,9 +180,14 @@ func (ot *OpenTok) GetProject(projectAPIKey string) (*Project, error) {
 	return project, nil
 }
 
-// ChangeProjectStatus changes the status of  project. The status is either
-// active or suspended.
+// ChangeProjectStatus changes the status of project. The status is
+// either active or suspended.
 func (ot *OpenTok) ChangeProjectStatus(projectAPIKey string, projectStatus ProjectStatus) (*Project, error) {
+	return ot.ChangeProjectStatusContext(context.Background(), projectAPIKey, projectStatus)
+}
+
+// ChangeProjectStatusContext uses ctx for HTTP requests.
+func (ot *OpenTok) ChangeProjectStatusContext(ctx context.Context, projectAPIKey string, projectStatus ProjectStatus) (*Project, error) {
 	if projectAPIKey == "" {
 		return nil, fmt.Errorf("Project status cannot be changed without a project API key")
 	}
@@ -196,8 +214,7 @@ func (ot *OpenTok) ChangeProjectStatus(projectAPIKey string, projectStatus Proje
 	req.Header.Add("X-OPENTOK-AUTH", jwt)
 	req.Header.Add("User-Agent", SDKName+"/"+SDKVersion)
 
-	client := &http.Client{}
-	res, err := client.Do(req)
+	res, err := ot.httpClient.Do(req.WithContext(ctx))
 	if err != nil {
 		return nil, err
 	}
@@ -217,6 +234,11 @@ func (ot *OpenTok) ChangeProjectStatus(projectAPIKey string, projectStatus Proje
 
 // RefreshProjectSecret generates a new API secret for a project.
 func (ot *OpenTok) RefreshProjectSecret(projectAPIKey string) (*Project, error) {
+	return ot.RefreshProjectSecretContext(context.Background(), projectAPIKey)
+}
+
+// RefreshProjectSecretContext uses ctx for HTTP requests.
+func (ot *OpenTok) RefreshProjectSecretContext(ctx context.Context, projectAPIKey string) (*Project, error) {
 	if projectAPIKey == "" {
 		return nil, fmt.Errorf("Project secret cannot be refreshed without a project API key")
 	}
@@ -236,8 +258,7 @@ func (ot *OpenTok) RefreshProjectSecret(projectAPIKey string) (*Project, error) 
 	req.Header.Add("X-OPENTOK-AUTH", jwt)
 	req.Header.Add("User-Agent", SDKName+"/"+SDKVersion)
 
-	client := &http.Client{}
-	res, err := client.Do(req)
+	res, err := ot.httpClient.Do(req.WithContext(ctx))
 	if err != nil {
 		return nil, err
 	}
@@ -255,9 +276,14 @@ func (ot *OpenTok) RefreshProjectSecret(projectAPIKey string) (*Project, error) 
 	return project, nil
 }
 
-// DeleteProject prevents the use of the project API key (and any OpenTok
-// sessions created with it).
+// DeleteProjectContext prevents the use of the project API key (and
+// any OpenTok sessions created with it).
 func (ot *OpenTok) DeleteProject(projectAPIKey string) error {
+	return ot.DeleteProjectContext(context.Background(), projectAPIKey)
+}
+
+// DeleteProjectContext uses ctx for HTTP requests.
+func (ot *OpenTok) DeleteProjectContext(ctx context.Context, projectAPIKey string) error {
 	if projectAPIKey == "" {
 		return fmt.Errorf("Project cannot be deleted without a project API key")
 	}
@@ -277,8 +303,7 @@ func (ot *OpenTok) DeleteProject(projectAPIKey string) error {
 	req.Header.Add("X-OPENTOK-AUTH", jwt)
 	req.Header.Add("User-Agent", SDKName+"/"+SDKVersion)
 
-	client := &http.Client{}
-	res, err := client.Do(req)
+	res, err := ot.httpClient.Do(req.WithContext(ctx))
 	if err != nil {
 		return err
 	}

--- a/opentok/archive.go
+++ b/opentok/archive.go
@@ -2,6 +2,7 @@ package opentok
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -216,6 +217,11 @@ type StorageOptions struct {
 // You can only record one archive at a time for a given session.
 // You can only record archives of sessions that use the OpenTok Media Router.
 func (ot *OpenTok) StartArchive(sessionID string, opts *ArchiveOptions) (*Archive, error) {
+	return ot.StartArchiveContext(context.Background(), sessionID, opts)
+}
+
+// StartArchiveContext uses ctx for HTTP requests.
+func (ot *OpenTok) StartArchiveContext(ctx context.Context, sessionID string, opts *ArchiveOptions) (*Archive, error) {
 	opts.SessionID = sessionID
 
 	if opts.Layout != nil {
@@ -260,8 +266,7 @@ func (ot *OpenTok) StartArchive(sessionID string, opts *ArchiveOptions) (*Archiv
 	req.Header.Add("X-OPENTOK-AUTH", jwt)
 	req.Header.Add("User-Agent", SDKName+"/"+SDKVersion)
 
-	client := &http.Client{}
-	res, err := client.Do(req)
+	res, err := ot.httpClient.Do(req.WithContext(ctx))
 	if err != nil {
 		return nil, err
 	}
@@ -287,6 +292,11 @@ func (ot *OpenTok) StartArchive(sessionID string, opts *ArchiveOptions) (*Archiv
 // last client disconnects from the session, or 60 minutes after the last
 // client stops publishing.
 func (ot *OpenTok) StopArchive(archiveID string) (*Archive, error) {
+	return ot.StopArchiveContext(context.Background(), archiveID)
+}
+
+// StopArchiveContext uses ctx for HTTP requests.
+func (ot *OpenTok) StopArchiveContext(ctx context.Context, archiveID string) (*Archive, error) {
 	if archiveID == "" {
 		return nil, fmt.Errorf("Archive recording cannot be stopped without an archive ID")
 	}
@@ -306,8 +316,7 @@ func (ot *OpenTok) StopArchive(archiveID string) (*Archive, error) {
 	req.Header.Add("X-OPENTOK-AUTH", jwt)
 	req.Header.Add("User-Agent", SDKName+"/"+SDKVersion)
 
-	client := &http.Client{}
-	res, err := client.Do(req)
+	res, err := ot.httpClient.Do(req.WithContext(ctx))
 	if err != nil {
 		return nil, err
 	}
@@ -330,6 +339,11 @@ func (ot *OpenTok) StopArchive(archiveID string) (*Archive, error) {
 // ListArchives returns the records of all archives for your project that are
 // in progress.
 func (ot *OpenTok) ListArchives(opts *ArchiveListOptions) (*ArchiveList, error) {
+	return ot.ListArchivesContext(context.Background(), opts)
+}
+
+// ListArchivesContext uses ctx for HTTP requests.
+func (ot *OpenTok) ListArchivesContext(ctx context.Context, opts *ArchiveListOptions) (*ArchiveList, error) {
 	params := []string{"?"}
 
 	if opts.Offset != 0 {
@@ -359,8 +373,7 @@ func (ot *OpenTok) ListArchives(opts *ArchiveListOptions) (*ArchiveList, error) 
 	req.Header.Add("X-OPENTOK-AUTH", jwt)
 	req.Header.Add("User-Agent", SDKName+"/"+SDKVersion)
 
-	client := &http.Client{}
-	res, err := client.Do(req)
+	res, err := ot.httpClient.Do(req.WithContext(ctx))
 	if err != nil {
 		return nil, err
 	}
@@ -384,6 +397,11 @@ func (ot *OpenTok) ListArchives(opts *ArchiveListOptions) (*ArchiveList, error) 
 
 // GetArchive returns a archive details record describing the archive.
 func (ot *OpenTok) GetArchive(archiveID string) (*Archive, error) {
+	return ot.GetArchiveContext(context.Background(), archiveID)
+}
+
+// GetArchiveContext uses ctx for HTTP requests.
+func (ot *OpenTok) GetArchiveContext(ctx context.Context, archiveID string) (*Archive, error) {
 	if archiveID == "" {
 		return nil, fmt.Errorf("Cannot get archive information without an archive ID")
 	}
@@ -403,8 +421,7 @@ func (ot *OpenTok) GetArchive(archiveID string) (*Archive, error) {
 	req.Header.Add("X-OPENTOK-AUTH", jwt)
 	req.Header.Add("User-Agent", SDKName+"/"+SDKVersion)
 
-	client := &http.Client{}
-	res, err := client.Do(req)
+	res, err := ot.httpClient.Do(req.WithContext(ctx))
 	if err != nil {
 		return nil, err
 	}
@@ -426,6 +443,11 @@ func (ot *OpenTok) GetArchive(archiveID string) (*Archive, error) {
 
 // DeleteArchive deletes a specific archive.
 func (ot *OpenTok) DeleteArchive(archiveID string) error {
+	return ot.DeleteArchiveContext(context.Background(), archiveID)
+}
+
+// DeleteArchiveContext uses ctx for HTTP requests.
+func (ot *OpenTok) DeleteArchiveContext(ctx context.Context, archiveID string) error {
 	if archiveID == "" {
 		return fmt.Errorf("Archive cannot be deleted without an archive ID")
 	}
@@ -445,8 +467,7 @@ func (ot *OpenTok) DeleteArchive(archiveID string) error {
 	req.Header.Add("X-OPENTOK-AUTH", jwt)
 	req.Header.Add("User-Agent", SDKName+"/"+SDKVersion)
 
-	client := &http.Client{}
-	res, err := client.Do(req)
+	res, err := ot.httpClient.Do(req.WithContext(ctx))
 	if err != nil {
 		return err
 	}
@@ -462,6 +483,11 @@ func (ot *OpenTok) DeleteArchive(archiveID string) error {
 // SetArchiveStorage let you can have OpenTok upload completed archives to an
 // Amazon S3 bucket (or an S3-compliant storage provider) or Microsoft Azure container.
 func (ot *OpenTok) SetArchiveStorage(opts *StorageOptions) (*StorageOptions, error) {
+	return ot.SetArchiveStorageContext(context.Background(), opts)
+}
+
+// SetArchiveStorageContext uses ctx for HTTP requests.
+func (ot *OpenTok) SetArchiveStorageContext(ctx context.Context, opts *StorageOptions) (*StorageOptions, error) {
 	if opts.Type != "s3" && opts.Type != "azure" {
 		return nil, fmt.Errorf("Only support Amazon S3 or Microsoft Azure for upload completed archives")
 	}
@@ -513,8 +539,7 @@ func (ot *OpenTok) SetArchiveStorage(opts *StorageOptions) (*StorageOptions, err
 	req.Header.Add("X-OPENTOK-AUTH", jwt)
 	req.Header.Add("User-Agent", SDKName+"/"+SDKVersion)
 
-	client := &http.Client{}
-	res, err := client.Do(req)
+	res, err := ot.httpClient.Do(req.WithContext(ctx))
 	if err != nil {
 		return nil, err
 	}
@@ -534,6 +559,11 @@ func (ot *OpenTok) SetArchiveStorage(opts *StorageOptions) (*StorageOptions, err
 
 // DeleteArchiveStorage deletes the configuration of archive storage.
 func (ot *OpenTok) DeleteArchiveStorage() error {
+	return ot.DeleteArchiveStorageContext(context.Background())
+}
+
+// DeleteArchiveStorageContext uses ctx for HTTP requests.
+func (ot *OpenTok) DeleteArchiveStorageContext(ctx context.Context) error {
 	//Create jwt token
 	jwt, err := ot.jwtToken(projectToken)
 	if err != nil {
@@ -549,8 +579,7 @@ func (ot *OpenTok) DeleteArchiveStorage() error {
 	req.Header.Add("X-OPENTOK-AUTH", jwt)
 	req.Header.Add("User-Agent", SDKName+"/"+SDKVersion)
 
-	client := &http.Client{}
-	res, err := client.Do(req)
+	res, err := ot.httpClient.Do(req.WithContext(ctx))
 	if err != nil {
 		return err
 	}
@@ -565,6 +594,11 @@ func (ot *OpenTok) DeleteArchiveStorage() error {
 
 // SetArchiveLayout dynamically change the layout type of a composed archive.
 func (ot *OpenTok) SetArchiveLayout(archiveID string, layout *Layout) (*Archive, error) {
+	return ot.SetArchiveLayoutContext(context.Background(), archiveID, layout)
+}
+
+// SetArchiveLayoutContext uses ctx for HTTP requests.
+func (ot *OpenTok) SetArchiveLayoutContext(ctx context.Context, archiveID string, layout *Layout) (*Archive, error) {
 	if archiveID == "" {
 		return nil, fmt.Errorf("Cannot change the layout type of a composed archive without an archive ID")
 	}
@@ -601,8 +635,7 @@ func (ot *OpenTok) SetArchiveLayout(archiveID string, layout *Layout) (*Archive,
 	req.Header.Add("X-OPENTOK-AUTH", jwt)
 	req.Header.Add("User-Agent", SDKName+"/"+SDKVersion)
 
-	client := &http.Client{}
-	res, err := client.Do(req)
+	res, err := ot.httpClient.Do(req.WithContext(ctx))
 	if err != nil {
 		return nil, err
 	}

--- a/opentok/broadcast.go
+++ b/opentok/broadcast.go
@@ -2,6 +2,7 @@ package opentok
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -65,7 +66,7 @@ type BroadcastURLs struct {
 	HLS string `json:"hls"`
 
 	// The configuration of RTMP.
-	RTMP []*RTMPConfig `json:rtmp`
+	RTMP []*RTMPConfig `json:"rtmp"`
 }
 
 // Broadcast defines the response returned from API.
@@ -123,10 +124,15 @@ type BroadcastList struct {
 	Items []*Broadcast `json:"items"`
 }
 
-// StartBroadcast starts a live streaming for an OpenTok session.
-// This broadcasts the session to an HLS (HTTP live streaming) or to RTMP
+// StartBroadcast starts a live streaming for an OpenTok session. This
+// broadcasts the session to an HLS (HTTP live streaming) or to RTMP
 // streams.
 func (ot *OpenTok) StartBroadcast(sessionID string, opts *BroadcastOptions) (*Broadcast, error) {
+	return ot.StartBroadcastContext(context.Background(), sessionID, opts)
+}
+
+// StartBroadcastContext uses ctx for HTTP requests.
+func (ot *OpenTok) StartBroadcastContext(ctx context.Context, sessionID string, opts *BroadcastOptions) (*Broadcast, error) {
 	opts.SessionID = sessionID
 
 	if opts.Layout != nil {
@@ -151,7 +157,7 @@ func (ot *OpenTok) StartBroadcast(sessionID string, opts *BroadcastOptions) (*Br
 
 	jsonStr, _ := json.Marshal(opts)
 
-	//Create jwt token
+	// Create jwt token
 	jwt, err := ot.jwtToken(projectToken)
 	if err != nil {
 		return nil, err
@@ -167,8 +173,7 @@ func (ot *OpenTok) StartBroadcast(sessionID string, opts *BroadcastOptions) (*Br
 	req.Header.Add("X-OPENTOK-AUTH", jwt)
 	req.Header.Add("User-Agent", SDKName+"/"+SDKVersion)
 
-	client := &http.Client{}
-	res, err := client.Do(req)
+	res, err := ot.httpClient.Do(req.WithContext(ctx))
 	if err != nil {
 		return nil, err
 	}
@@ -191,6 +196,11 @@ func (ot *OpenTok) StartBroadcast(sessionID string, opts *BroadcastOptions) (*Br
 // StopBroadcast stops a live broadcast of an OpenTok session.
 // Note that broadcasts automatically stop 120 minutes after they are started.
 func (ot *OpenTok) StopBroadcast(broadcastID string) (*Broadcast, error) {
+	return ot.StopBroadcastContext(context.Background(), broadcastID)
+}
+
+// StopBroadcastContext uses ctx for HTTP requests.
+func (ot *OpenTok) StopBroadcastContext(ctx context.Context, broadcastID string) (*Broadcast, error) {
 	if broadcastID == "" {
 		return nil, fmt.Errorf("Live stremaing broadcast cannot be stopped without an broadcast ID")
 	}
@@ -210,8 +220,7 @@ func (ot *OpenTok) StopBroadcast(broadcastID string) (*Broadcast, error) {
 	req.Header.Add("X-OPENTOK-AUTH", jwt)
 	req.Header.Add("User-Agent", SDKName+"/"+SDKVersion)
 
-	client := &http.Client{}
-	res, err := client.Do(req)
+	res, err := ot.httpClient.Do(req.WithContext(ctx))
 	if err != nil {
 		return nil, err
 	}
@@ -231,10 +240,15 @@ func (ot *OpenTok) StopBroadcast(broadcastID string) (*Broadcast, error) {
 	return broadcast, nil
 }
 
-// ListBroadcasts returns the records of all broadcasts for your project that
-// are in progress and started. Completed broadcasts are not included in the
-// listing.
+// ListBroadcasts returns the records of all broadcasts for your
+// project that are in progress and started. Completed broadcasts are
+// not included in the listing.
 func (ot *OpenTok) ListBroadcasts(opts *BroadcastListOptions) (*BroadcastList, error) {
+	return ot.ListBroadcastsContext(context.Background(), opts)
+}
+
+// ListBroadcastsContext uses ctx for HTTP requests.
+func (ot *OpenTok) ListBroadcastsContext(ctx context.Context, opts *BroadcastListOptions) (*BroadcastList, error) {
 	params := []string{"?"}
 
 	if opts.Offset != 0 {
@@ -264,8 +278,7 @@ func (ot *OpenTok) ListBroadcasts(opts *BroadcastListOptions) (*BroadcastList, e
 	req.Header.Add("X-OPENTOK-AUTH", jwt)
 	req.Header.Add("User-Agent", SDKName+"/"+SDKVersion)
 
-	client := &http.Client{}
-	res, err := client.Do(req)
+	res, err := ot.httpClient.Do(req.WithContext(ctx))
 	if err != nil {
 		return nil, err
 	}
@@ -289,6 +302,11 @@ func (ot *OpenTok) ListBroadcasts(opts *BroadcastListOptions) (*BroadcastList, e
 
 // GetBroadcast returns a broadcast that is in-progress.
 func (ot *OpenTok) GetBroadcast(broadcastID string) (*Broadcast, error) {
+	return ot.GetBroadcastContext(context.Background(), broadcastID)
+}
+
+// GetBroadcastContext uses ctx for HTTP requests.
+func (ot *OpenTok) GetBroadcastContext(ctx context.Context, broadcastID string) (*Broadcast, error) {
 	if broadcastID == "" {
 		return nil, fmt.Errorf("Cannot get broadcast information without an broadcast ID")
 	}
@@ -308,8 +326,7 @@ func (ot *OpenTok) GetBroadcast(broadcastID string) (*Broadcast, error) {
 	req.Header.Add("X-OPENTOK-AUTH", jwt)
 	req.Header.Add("User-Agent", SDKName+"/"+SDKVersion)
 
-	client := &http.Client{}
-	res, err := client.Do(req)
+	res, err := ot.httpClient.Do(req.WithContext(ctx))
 	if err != nil {
 		return nil, err
 	}
@@ -332,6 +349,11 @@ func (ot *OpenTok) GetBroadcast(broadcastID string) (*Broadcast, error) {
 // SetBroadcastLayout dynamically changes the layout type of a live streaming
 // broadcast.
 func (ot *OpenTok) SetBroadcastLayout(broadcastID string, layout *Layout) (*Broadcast, error) {
+	return ot.SetBroadcastLayoutContext(context.Background(), broadcastID, layout)
+}
+
+// SetBroadcastLayoutContext uses ctx for HTTP requests.
+func (ot *OpenTok) SetBroadcastLayoutContext(ctx context.Context, broadcastID string, layout *Layout) (*Broadcast, error) {
 	if broadcastID == "" {
 		return nil, fmt.Errorf("Cannot change the layout type of a live streaming broadcast without an broadcast ID")
 	}
@@ -368,8 +390,7 @@ func (ot *OpenTok) SetBroadcastLayout(broadcastID string, layout *Layout) (*Broa
 	req.Header.Add("X-OPENTOK-AUTH", jwt)
 	req.Header.Add("User-Agent", SDKName+"/"+SDKVersion)
 
-	client := &http.Client{}
-	res, err := client.Do(req)
+	res, err := ot.httpClient.Do(req.WithContext(ctx))
 	if err != nil {
 		return nil, err
 	}

--- a/opentok/example_opentok_test.go
+++ b/opentok/example_opentok_test.go
@@ -1,13 +1,18 @@
 package opentok_test
 
-import "github.com/calvertyang/opentok-go-sdk/v2/opentok"
+import (
+	"net/http"
+	"time"
+
+	"github.com/calvertyang/opentok-go-sdk/v2/opentok"
+)
 
 const (
 	apiKey    = "<your api key here>"
 	apiSecret = "<your api secret here>"
 )
 
-var ot = opentok.New(apiKey, apiSecret)
+var ot = opentok.New(apiKey, apiSecret, nil)
 
 func ExampleNew() {
 	const (
@@ -15,5 +20,6 @@ func ExampleNew() {
 		apiSecret = "ba7816bf8f01cfea414140de5dae2223b00361a3"
 	)
 
-	opentok.New(apiKey, apiSecret)
+	client := &http.Client{Timeout: 120 * time.Second}
+	opentok.New(apiKey, apiSecret, client)
 }

--- a/opentok/moderation.go
+++ b/opentok/moderation.go
@@ -1,12 +1,18 @@
 package opentok
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 )
 
 // ForceDisconnect disconnects a client from an OpenTok session via server-side
 func (ot *OpenTok) ForceDisconnect(sessionID, connectionID string) error {
+	return ot.ForceDisconnectContext(context.Background(), sessionID, connectionID)
+}
+
+// ForceDisconnectContext uses ctx for HTTP requests.
+func (ot *OpenTok) ForceDisconnectContext(ctx context.Context, sessionID, connectionID string) error {
 	if sessionID == "" {
 		return fmt.Errorf("Connection cannot be disconnected without a session ID")
 	}
@@ -30,8 +36,7 @@ func (ot *OpenTok) ForceDisconnect(sessionID, connectionID string) error {
 	req.Header.Add("X-OPENTOK-AUTH", jwt)
 	req.Header.Add("User-Agent", SDKName+"/"+SDKVersion)
 
-	client := &http.Client{}
-	res, err := client.Do(req)
+	res, err := ot.httpClient.Do(req.WithContext(ctx))
 	if err != nil {
 		return err
 	}

--- a/opentok/opentok.go
+++ b/opentok/opentok.go
@@ -2,11 +2,17 @@ package opentok
 
 import (
 	"fmt"
+	"net/http"
 	"time"
 
 	jwt "github.com/dgrijalva/jwt-go"
 	"github.com/google/uuid"
 )
+
+// HTTPClient is an interface to allow custom clients and timeouts.
+type HTTPClient interface {
+	Do(req *http.Request) (*http.Response, error)
+}
 
 // OpenTok API host URL
 const defaultAPIHost = "https://api.opentok.com"
@@ -28,11 +34,18 @@ type OpenTok struct {
 	apiKey    string
 	apiSecret string
 	apiHost   string
+
+	httpClient HTTPClient
 }
 
 // New returns an initialized OpenTok instance with the API key and API secret.
-func New(apiKey, apiSecret string) *OpenTok {
-	return &OpenTok{apiKey, apiSecret, defaultAPIHost}
+func New(apiKey, apiSecret string, client HTTPClient) *OpenTok {
+	return &OpenTok{
+		apiKey:     apiKey,
+		apiSecret:  apiSecret,
+		apiHost:    defaultAPIHost,
+		httpClient: client,
+	}
 }
 
 // SetAPIHost is used to set OpenTok API Host to specific URL

--- a/opentok/opentok_test.go
+++ b/opentok/opentok_test.go
@@ -2,6 +2,7 @@ package opentok
 
 import (
 	"log"
+	"net/http"
 	"testing"
 
 	jwt "github.com/dgrijalva/jwt-go"
@@ -13,12 +14,12 @@ const (
 	apiSecret = "<your api secret here>"
 )
 
-var ot = New(apiKey, apiSecret)
+var ot = New(apiKey, apiSecret, http.DefaultClient)
 
 func TestNew(t *testing.T) {
-	expect := &OpenTok{apiKey, apiSecret, defaultAPIHost}
+	expect := &OpenTok{apiKey, apiSecret, defaultAPIHost, nil}
 
-	actual := New(apiKey, apiSecret)
+	actual := New(apiKey, apiSecret, nil)
 
 	assert.Equal(t, expect, actual)
 }
@@ -33,7 +34,7 @@ func TestOpenTok_SetAPIHost(t *testing.T) {
 }
 
 func TestOpenTok_JwtToken(t *testing.T) {
-	ot := New(apiKey, apiSecret)
+	ot := New(apiKey, apiSecret, nil)
 
 	// Validate  project token
 	tokenString, err := ot.jwtToken(projectToken)

--- a/opentok/session.go
+++ b/opentok/session.go
@@ -1,6 +1,7 @@
 package opentok
 
 import (
+	"context"
 	"crypto/hmac"
 	"crypto/sha1"
 	"encoding/base64"
@@ -122,6 +123,11 @@ type SessionIDInfo struct {
 
 // CreateSession generates a new session.
 func (ot *OpenTok) CreateSession(opts *SessionOptions) (*Session, error) {
+	return ot.CreateSessionContext(context.Background(), opts)
+}
+
+// CreateSessionContext uses ctx for HTTP requests.
+func (ot *OpenTok) CreateSessionContext(ctx context.Context, opts *SessionOptions) (*Session, error) {
 	params := url.Values{}
 
 	if opts.ArchiveMode != "" {
@@ -151,8 +157,7 @@ func (ot *OpenTok) CreateSession(opts *SessionOptions) (*Session, error) {
 	req.Header.Add("X-OPENTOK-AUTH", jwt)
 	req.Header.Add("User-Agent", SDKName+"/"+SDKVersion)
 
-	client := &http.Client{}
-	res, err := client.Do(req)
+	res, err := ot.httpClient.Do(req.WithContext(ctx))
 	if err != nil {
 		return nil, err
 	}

--- a/opentok/signal.go
+++ b/opentok/signal.go
@@ -2,6 +2,7 @@ package opentok
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -19,6 +20,11 @@ type SignalData struct {
 
 // SendSessionSignal send signals to all participants in an active OpenTok session.
 func (ot *OpenTok) SendSessionSignal(sessionID string, data *SignalData) error {
+	return ot.SendSessionSignalContext(context.Background(), sessionID, data)
+}
+
+// SendSessionSignalContext uses ctx for HTTP requests.
+func (ot *OpenTok) SendSessionSignalContext(ctx context.Context, sessionID string, data *SignalData) error {
 	if sessionID == "" {
 		return fmt.Errorf("Signal cannot be sent without a session ID")
 	}
@@ -41,8 +47,7 @@ func (ot *OpenTok) SendSessionSignal(sessionID string, data *SignalData) error {
 	req.Header.Add("X-OPENTOK-AUTH", jwt)
 	req.Header.Add("User-Agent", SDKName+"/"+SDKVersion)
 
-	client := &http.Client{}
-	res, err := client.Do(req)
+	res, err := ot.httpClient.Do(req.WithContext(ctx))
 	if err != nil {
 		return err
 	}
@@ -55,8 +60,13 @@ func (ot *OpenTok) SendSessionSignal(sessionID string, data *SignalData) error {
 	return nil
 }
 
-// SendConnectionSignal send signals to a specific client in an active OpenTok session
+// SendConnectionSignal send signals to a specific client in an active OpenTok session.
 func (ot *OpenTok) SendConnectionSignal(sessionID, connectionID string, data *SignalData) error {
+	return ot.SendConnectionSignalContext(context.Background(), sessionID, connectionID, data)
+}
+
+// SendConnectionSignalContext uses ctx for HTTP requests.
+func (ot *OpenTok) SendConnectionSignalContext(ctx context.Context, sessionID, connectionID string, data *SignalData) error {
 	if sessionID == "" {
 		return fmt.Errorf("Signal cannot be sent without a session ID")
 	}
@@ -83,8 +93,7 @@ func (ot *OpenTok) SendConnectionSignal(sessionID, connectionID string, data *Si
 	req.Header.Add("X-OPENTOK-AUTH", jwt)
 	req.Header.Add("User-Agent", SDKName+"/"+SDKVersion)
 
-	client := &http.Client{}
-	res, err := client.Do(req)
+	res, err := ot.httpClient.Do(req.WithContext(ctx))
 	if err != nil {
 		return err
 	}

--- a/opentok/sip.go
+++ b/opentok/sip.go
@@ -2,6 +2,7 @@ package opentok
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -75,6 +76,11 @@ type SIPCall struct {
 // an audio-only stream. The OpenTok Media Router mixes audio from other streams
 // in the session and sends the mixed audio to your SIP endpoint.
 func (ot *OpenTok) Dial(sessionID string, opts *DialOptions) (*SIPCall, error) {
+	return ot.DialContext(context.Background(), sessionID, opts)
+}
+
+// DialContext uses ctx for HTTP requests.
+func (ot *OpenTok) DialContext(ctx context.Context, sessionID string, opts *DialOptions) (*SIPCall, error) {
 	if sessionID == "" {
 		return nil, fmt.Errorf("SIP call cannot be initiated without an session ID")
 	}
@@ -111,8 +117,7 @@ func (ot *OpenTok) Dial(sessionID string, opts *DialOptions) (*SIPCall, error) {
 	req.Header.Add("X-OPENTOK-AUTH", jwt)
 	req.Header.Add("User-Agent", SDKName+"/"+SDKVersion)
 
-	client := &http.Client{}
-	res, err := client.Do(req)
+	res, err := ot.httpClient.Do(req.WithContext(ctx))
 	if err != nil {
 		return nil, err
 	}

--- a/opentok/stream.go
+++ b/opentok/stream.go
@@ -2,6 +2,7 @@ package opentok
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -50,6 +51,11 @@ type StreamClassOptions struct {
 
 // ListStreams returns the stream records in a session.
 func (ot *OpenTok) ListStreams(sessionID string) (*StreamList, error) {
+	return ot.ListStreamsContext(context.Background(), sessionID)
+}
+
+// ListStreamsContext uses ctx for HTTP requests.
+func (ot *OpenTok) ListStreamsContext(ctx context.Context, sessionID string) (*StreamList, error) {
 	if sessionID == "" {
 		return nil, fmt.Errorf("Cannot get all streams information without a session ID")
 	}
@@ -69,8 +75,7 @@ func (ot *OpenTok) ListStreams(sessionID string) (*StreamList, error) {
 	req.Header.Add("X-OPENTOK-AUTH", jwt)
 	req.Header.Add("User-Agent", SDKName+"/"+SDKVersion)
 
-	client := &http.Client{}
-	res, err := client.Do(req)
+	res, err := ot.httpClient.Do(req.WithContext(ctx))
 	if err != nil {
 		return nil, err
 	}
@@ -90,6 +95,11 @@ func (ot *OpenTok) ListStreams(sessionID string) (*StreamList, error) {
 
 // GetStream returns a stream details record describing the stream.
 func (ot *OpenTok) GetStream(sessionID, streamID string) (*Stream, error) {
+	return ot.GetStreamContext(context.Background(), sessionID, streamID)
+}
+
+// GetStreamContext uses ctx for HTTP requests.
+func (ot *OpenTok) GetStreamContext(ctx context.Context, sessionID, streamID string) (*Stream, error) {
 	if sessionID == "" {
 		return nil, fmt.Errorf("Cannot get stream information without a session ID")
 	}
@@ -113,8 +123,7 @@ func (ot *OpenTok) GetStream(sessionID, streamID string) (*Stream, error) {
 	req.Header.Add("X-OPENTOK-AUTH", jwt)
 	req.Header.Add("User-Agent", SDKName+"/"+SDKVersion)
 
-	client := &http.Client{}
-	res, err := client.Do(req)
+	res, err := ot.httpClient.Do(req.WithContext(ctx))
 	if err != nil {
 		return nil, err
 	}
@@ -132,9 +141,13 @@ func (ot *OpenTok) GetStream(sessionID, streamID string) (*Stream, error) {
 	return stream, nil
 }
 
-// SetStreamClassLists changes the composed archive layout classes for an
-// OpenTok stream
+// SetStreamClassLists changes the composed archive layout classes for an OpenTok stream
 func (ot *OpenTok) SetStreamClassLists(sessionID string, opts *StreamClassOptions) (*StreamList, error) {
+	return ot.SetStreamClassListsContext(context.Background(), sessionID, opts)
+}
+
+// SetStreamClassListsContext uses ctx for HTTP requests.
+func (ot *OpenTok) SetStreamClassListsContext(ctx context.Context, sessionID string, opts *StreamClassOptions) (*StreamList, error) {
 	if sessionID == "" {
 		return nil, fmt.Errorf("Cannot change the live streaming layout classes for an OpenTok stream without an session ID")
 	}
@@ -157,8 +170,7 @@ func (ot *OpenTok) SetStreamClassLists(sessionID string, opts *StreamClassOption
 	req.Header.Add("X-OPENTOK-AUTH", jwt)
 	req.Header.Add("User-Agent", SDKName+"/"+SDKVersion)
 
-	client := &http.Client{}
-	res, err := client.Do(req)
+	res, err := ot.httpClient.Do(req.WithContext(ctx))
 	if err != nil {
 		return nil, err
 	}

--- a/opentok/version.go
+++ b/opentok/version.go
@@ -4,4 +4,4 @@ package opentok
 const SDKName = "OpenTok-Go-SDK"
 
 // SDKVersion is the version of this SDK
-const SDKVersion = "2.0.0"
+const SDKVersion = "2.1.0"


### PR DESCRIPTION
Hello,

I really like your library, but noticed it doesn't accept custom HTTP clients for performing the Tokbox API calls. I think this is an important feature to have for setting timeouts or other configuration.

Additionally, I wanted to allow the option of performing requests with a `context.Context` to provide even more flexibility.

This is a similar approach to what I saw in another fork of this project, but I wanted to contribute this back upstream.

Thanks.
